### PR TITLE
Clean up nuke-to-fusion's __init__   file

### DIFF
--- a/app/nusion/model/nodes/nuke_to_fusion/__init__.py
+++ b/app/nusion/model/nodes/nuke_to_fusion/__init__.py
@@ -3,16 +3,18 @@ Import all effects from the nodes folder to allow them to be easily called from
 other scripts using the node's effect type attribute.
 """
 
-from nusion.model.nodes.nuke_to_fusion import   BaseAttributes, \
-                                                CommonAttributes, \
-                                                Blur, \
-                                                ColorCorrect, \
-                                                Transform, \
-                                                Invert, \
-                                                Premult, \
-                                                Unpremult, \
-                                                Write, \
-                                                Dot
+from nusion.model.nodes.nuke_to_fusion import (
+    BaseAttributes,
+    CommonAttributes,
+    Blur,
+    ColorCorrect,
+    Transform,
+    Invert,
+    Premult,
+    Unpremult,
+    Write,
+    Dot,
+)
 
 def convert(node):
     """ List of effect conversion functions """

--- a/app/nusion/model/nodes/nuke_to_fusion/__init__.py
+++ b/app/nusion/model/nodes/nuke_to_fusion/__init__.py
@@ -16,34 +16,30 @@ from nusion.model.nodes.nuke_to_fusion import (
     Dot,
 )
 
-def convert(node):
-    """ List of effect conversion functions """
+__all__ = (
+    "BaseAttributes",
+    "CommonAttributes",
+    "Blur",
+    "ColorCorrect",
+    "Transform",
+    "Invert",
+    "Premult",
+    "Unpremult",
+    "Write",
+    "Dot",
+)
 
+# Utility modules that shouldn't be treated as node converters
+UTILITY_MODULES = {"BaseAttributes", "CommonAttributes"}
+
+def convert(node):
+    """Convert node based on its effect type"""
     base_attribs = BaseAttributes.convert(node)
     common_attribs = CommonAttributes.convert(node)
-
-    if node.effect == "Blur":
-        return base_attribs, {**common_attribs, **Blur.convert(node)}
-
-    if node.effect == "ColorCorrect":
-        return base_attribs, {**common_attribs, **ColorCorrect.convert(node)}
-
-    if node.effect == "Transform":
-        return base_attribs, {**common_attribs, **Transform.convert(node)}
-
-    if node.effect == "Invert":
-        return base_attribs, {**common_attribs, **Invert.convert(node)}
-
-    if node.effect == "Premult":
-        return base_attribs, {**common_attribs, **Premult.convert(node)}
-
-    if node.effect == "Unpremult":
-        return base_attribs, {**common_attribs, **Premult.convert(node)}
-
-    if node.effect == "Write":
-        return base_attribs, {**common_attribs, **Write.convert(node)}
-
-    if node.effect == "Dot":
-        return base_attribs, {**common_attribs, **Dot.convert(node)}
-
-    raise ValueError("Node effect '{0}' not currently supported.".format(node.effect))
+    
+    if node.effect in __all__ and node.effect not in UTILITY_MODULES:
+        # Use globals() to dynamically get the module by name
+        converter = globals()[node.effect]
+        return base_attribs, {**common_attribs, **converter.convert(node)}
+        
+    raise ValueError(f"Node effect '{node.effect}' not currently supported.")


### PR DESCRIPTION
This PR is a small one but one that makes it a bit cleaner if you ask me.

The first part simply wraps the imports between `()` instead of using `/` per line.
Now you just need to make a new row, add your converter and that's it.

Second is that I have added a `__all__` tuple with all the imports in it. This is used if any other python file uses `import nuke_to_fusion`. You can then access each converter like this `nuke_to_fusion.Invert`

It's not used in this codebase but with all the imports existing inside `__all__` we can now use it to itterate in the `convert()` function.

So instead of needing to copy the long code you only need to add the name of your converter in the `import` tuple and the `__all__` tuple.

You might like the old way better and that's ok with me :) but personally I do like wrapping the imports in a tuple as that's how Ruff, autopep, black and pylance formats multi-imports.